### PR TITLE
Fix XAML layout and SDK warning

### DIFF
--- a/SqlcmdGuiApp/MainWindow.xaml
+++ b/SqlcmdGuiApp/MainWindow.xaml
@@ -6,17 +6,9 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <ComboBox x:Name="AuthComboBox" Margin="0,0,0,10">
-            <ComboBoxItem Content="Windows Authentication"/>
-            <ComboBoxItem Content="SQL Server Authentication"/>
-        </ComboBox>
-        <StackPanel x:Name="SqlAuthPanel" Grid.Row="1" Visibility="Collapsed">
-            <TextBlock Text="Username:"/>
-            <TextBox x:Name="UsernameBox"/>
-            <TextBlock Text="Password:"/>
-            <PasswordBox x:Name="PasswordBox"/>
-        </StackPanel>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="Auto"/>

--- a/SqlcmdGuiApp/MainWindow.xaml.cs
+++ b/SqlcmdGuiApp/MainWindow.xaml.cs
@@ -57,11 +57,6 @@ namespace SqlcmdGuiApp
             }
         }
 
-        private void AuthComboBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
-        {
-            SqlAuthPanel.Visibility = AuthComboBox.SelectedIndex == 1 ? Visibility.Visible : Visibility.Collapsed;
-        }
-
         private void ExecuteButton_Click(object sender, RoutedEventArgs e)
         {
             if (!File.Exists(FilePathTextBox.Text))

--- a/SqlcmdGuiApp/SqlcmdGuiApp.csproj
+++ b/SqlcmdGuiApp/SqlcmdGuiApp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>


### PR DESCRIPTION
## Summary
- remove duplicate controls in `MainWindow.xaml`
- ensure `Grid.RowDefinitions` and `Grid.ColumnDefinitions` are declared before content
- update project to use `Microsoft.NET.Sdk`
- remove duplicate event handler

## Testing
- `dotnet build SqlcmdGuiApp/SqlcmdGuiApp.csproj -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6859774ac78c8332aed8cbc770d534ec