### PR TITLE
Fix nullable reference warnings

### DIFF
--- a/SqlcmdGuiApp/App.xaml.cs
+++ b/SqlcmdGuiApp/App.xaml.cs
@@ -37,7 +37,7 @@ namespace SqlcmdGuiApp
 
         private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            LogError(e.ExceptionObject.ToString());
+            LogError(e.ExceptionObject?.ToString() ?? string.Empty);
         }
 
         private void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)

--- a/SqlcmdGuiApp/MainWindow.xaml.cs
+++ b/SqlcmdGuiApp/MainWindow.xaml.cs
@@ -104,6 +104,10 @@ namespace SqlcmdGuiApp
             try
             {
                 var process = Process.Start(psi);
+                if (process == null)
+                {
+                    throw new InvalidOperationException("Failed to start sqlcmd process.");
+                }
                 process.WaitForExit();
                 var output = process.StandardOutput.ReadToEnd();
                 var error = process.StandardError.ReadToEnd();
@@ -121,7 +125,7 @@ namespace SqlcmdGuiApp
 
     public class SqlParameter
     {
-        public string Name { get; set; }
-        public string Value { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Value { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
## Summary
- ensure `Process.Start` result isn't null
- initialize `SqlParameter` properties
- guard against null `ExceptionObject`

## Testing
- `dotnet build SqlcmdGuiApp/SqlcmdGuiApp.csproj -nologo` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68597a8cf708833296fe75b5957298ac