### PR TITLE
Add connection security options

### DIFF
--- a/SqlcmdGuiApp/MainWindow.xaml
+++ b/SqlcmdGuiApp/MainWindow.xaml
@@ -40,6 +40,20 @@
                 <TextBlock Text="Password:" Margin="10 0"/>
                 <PasswordBox x:Name="PasswordBox" Width="100"/>
             </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0 2">
+                <TextBlock Text="Encrypt:" Width="80"/>
+                <ComboBox x:Name="EncryptComboBox" Width="200">
+                    <ComboBoxItem Content="Optional" IsSelected="True"/>
+                    <ComboBoxItem Content="Mandatory"/>
+                    <ComboBoxItem Content="Strict"/>
+                </ComboBox>
+            </StackPanel>
+            <CheckBox x:Name="TrustServerCertificateCheckBox" Content="Trust Server Certificate" Margin="0 2"/>
+            <CheckBox x:Name="ReadOnlyIntentCheckBox" Content="ReadOnly Application Intent" Margin="0 2"/>
+            <StackPanel Orientation="Horizontal" Margin="0 2">
+                <TextBlock Text="Advanced:" Width="80"/>
+                <TextBox x:Name="AdvancedOptionsTextBox" Width="200"/>
+            </StackPanel>
         </StackPanel>
 
         <GroupBox Header="Parameters" Grid.Row="2" Grid.ColumnSpan="2" Margin="0 5">

--- a/SqlcmdGuiApp/MainWindow.xaml.cs
+++ b/SqlcmdGuiApp/MainWindow.xaml.cs
@@ -92,6 +92,30 @@ namespace SqlcmdGuiApp
                 psi.ArgumentList.Add("-E");
             }
 
+            var encrypt = (EncryptComboBox.SelectedItem as ComboBoxItem)?.Content?.ToString()?.ToLower();
+            if (!string.IsNullOrEmpty(encrypt))
+            {
+                psi.ArgumentList.Add("--encrypt");
+                psi.ArgumentList.Add(encrypt);
+            }
+
+            if (TrustServerCertificateCheckBox.IsChecked == true)
+            {
+                psi.ArgumentList.Add("--trust-server-certificate");
+            }
+
+            if (ReadOnlyIntentCheckBox.IsChecked == true)
+            {
+                psi.ArgumentList.Add("--application-intent");
+                psi.ArgumentList.Add("ReadOnly");
+            }
+
+            if (!string.IsNullOrWhiteSpace(AdvancedOptionsTextBox.Text))
+            {
+                psi.ArgumentList.Add("--connection-string");
+                psi.ArgumentList.Add(AdvancedOptionsTextBox.Text);
+            }
+
             foreach (var p in Parameters)
             {
                 psi.ArgumentList.Add("-v");


### PR DESCRIPTION
## Summary
- add encrypt dropdown, trust certificate checkbox, readonly intent checkbox, and advanced options field
- pass selected options as `sqlcmd` arguments

## Testing
- `dotnet build SqlcmdGuiApp/SqlcmdGuiApp.csproj -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a51468c0483329259c981bb76f307