### PR TITLE
Display current Windows account when using Windows Authentication

### DIFF
--- a/SqlcmdGuiApp/MainWindow.xaml
+++ b/SqlcmdGuiApp/MainWindow.xaml
@@ -34,6 +34,10 @@
                     <ComboBoxItem Content="SQL"/>
                 </ComboBox>
             </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0 2" x:Name="WindowsAuthPanel" Visibility="Collapsed">
+                <TextBlock Text="Account:" Width="80"/>
+                <TextBlock x:Name="WindowsAccountTextBlock" VerticalAlignment="Center"/>
+            </StackPanel>
             <StackPanel Orientation="Horizontal" Margin="0 2" x:Name="SqlAuthPanel" Visibility="Collapsed">
                 <TextBlock Text="User:" Width="80"/>
                 <TextBox x:Name="UserTextBox" Width="100"/>

--- a/SqlcmdGuiApp/MainWindow.xaml.cs
+++ b/SqlcmdGuiApp/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Security.Principal;
 
 namespace SqlcmdGuiApp
 {
@@ -20,15 +21,23 @@ namespace SqlcmdGuiApp
             InitializeComponent();
             // Hook the event after initialization to avoid early invocation while components load
             AuthComboBox.SelectionChanged += AuthComboBox_SelectionChanged;
-            
+
             ParametersPanel.ItemsSource = Parameters;
+
+            // Set initial visibility and account information
+            AuthComboBox_SelectionChanged(null, null);
         }
 
         private void AuthComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (SqlAuthPanel == null) return; // may be null during XAML load
-            SqlAuthPanel.Visibility =
-                AuthComboBox.SelectedIndex == 1 ? Visibility.Visible : Visibility.Collapsed;
+            if (SqlAuthPanel == null || WindowsAuthPanel == null) return; // may be null during XAML load
+            var useSqlAuth = AuthComboBox.SelectedIndex == 1;
+            SqlAuthPanel.Visibility = useSqlAuth ? Visibility.Visible : Visibility.Collapsed;
+            WindowsAuthPanel.Visibility = useSqlAuth ? Visibility.Collapsed : Visibility.Visible;
+            if (!useSqlAuth)
+            {
+                WindowsAccountTextBlock.Text = System.Security.Principal.WindowsIdentity.GetCurrent()?.Name ?? string.Empty;
+            }
         }
 
         private void BrowseButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- add a panel showing the Windows account
- update the authentication change logic to toggle the panel and set the account name

## Testing
- `dotnet build SqlcmdGuiApp/SqlcmdGuiApp.csproj -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a5367228083329d98029abd3670e7