### PR TITLE
Fix sqlcmd flags for security options

### DIFF
--- a/SqlcmdGuiApp/MainWindow.xaml
+++ b/SqlcmdGuiApp/MainWindow.xaml
@@ -47,17 +47,13 @@
             <StackPanel Orientation="Horizontal" Margin="0 2">
                 <TextBlock Text="Encrypt:" Width="80"/>
                 <ComboBox x:Name="EncryptComboBox" Width="200">
-                    <ComboBoxItem Content="Optional" IsSelected="True"/>
-                    <ComboBoxItem Content="Mandatory"/>
-                    <ComboBoxItem Content="Strict"/>
+                    <ComboBoxItem Content="true" IsSelected="True"/>
+                    <ComboBoxItem Content="false"/>
+                    <ComboBoxItem Content="disable"/>
                 </ComboBox>
             </StackPanel>
             <CheckBox x:Name="TrustServerCertificateCheckBox" Content="Trust Server Certificate" Margin="0 2"/>
             <CheckBox x:Name="ReadOnlyIntentCheckBox" Content="ReadOnly Application Intent" Margin="0 2"/>
-            <StackPanel Orientation="Horizontal" Margin="0 2">
-                <TextBlock Text="Advanced:" Width="80"/>
-                <TextBox x:Name="AdvancedOptionsTextBox" Width="200"/>
-            </StackPanel>
         </StackPanel>
 
         <GroupBox Header="Parameters" Grid.Row="2" Grid.ColumnSpan="2" Margin="0 5">

--- a/SqlcmdGuiApp/MainWindow.xaml.cs
+++ b/SqlcmdGuiApp/MainWindow.xaml.cs
@@ -104,26 +104,21 @@ namespace SqlcmdGuiApp
             var encrypt = (EncryptComboBox.SelectedItem as ComboBoxItem)?.Content?.ToString()?.ToLower();
             if (!string.IsNullOrEmpty(encrypt))
             {
-                psi.ArgumentList.Add("--encrypt");
+                psi.ArgumentList.Add("-N");
                 psi.ArgumentList.Add(encrypt);
             }
 
             if (TrustServerCertificateCheckBox.IsChecked == true)
             {
-                psi.ArgumentList.Add("--trust-server-certificate");
+                psi.ArgumentList.Add("-C");
             }
 
             if (ReadOnlyIntentCheckBox.IsChecked == true)
             {
-                psi.ArgumentList.Add("--application-intent");
+                psi.ArgumentList.Add("-K");
                 psi.ArgumentList.Add("ReadOnly");
             }
 
-            if (!string.IsNullOrWhiteSpace(AdvancedOptionsTextBox.Text))
-            {
-                psi.ArgumentList.Add("--connection-string");
-                psi.ArgumentList.Add(AdvancedOptionsTextBox.Text);
-            }
 
             foreach (var p in Parameters)
             {


### PR DESCRIPTION
## Summary
- connect encryption combo uses `-N` values
- trust server certificate flag is now `-C`
- read-only intent uses `-K`
- removed `--connection-string` field

## Testing
- `dotnet build SqlcmdGuiApp/SqlcmdGuiApp.csproj -clp:ErrorsOnly` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685a5add24f88332abb461ea70de3018