### PR TITLE
Add connection test and command-line display

### DIFF
--- a/SqlcmdGuiApp/CommandLineWindow.xaml
+++ b/SqlcmdGuiApp/CommandLineWindow.xaml
@@ -1,0 +1,8 @@
+<Window x:Class="SqlcmdGuiApp.CommandLineWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Command Line" Height="200" Width="600">
+    <Grid Margin="5">
+        <TextBox x:Name="CommandTextBox" IsReadOnly="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"/>
+    </Grid>
+</Window>

--- a/SqlcmdGuiApp/CommandLineWindow.xaml.cs
+++ b/SqlcmdGuiApp/CommandLineWindow.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows;
+
+namespace SqlcmdGuiApp
+{
+    public partial class CommandLineWindow : Window
+    {
+        public CommandLineWindow(string commandLine)
+        {
+            InitializeComponent();
+            CommandTextBox.Text = commandLine;
+            CommandTextBox.Focus();
+            CommandTextBox.SelectAll();
+        }
+    }
+}

--- a/SqlcmdGuiApp/MainWindow.xaml
+++ b/SqlcmdGuiApp/MainWindow.xaml
@@ -71,6 +71,10 @@
             </ScrollViewer>
         </GroupBox>
 
-        <Button Content="Execute" Grid.Row="3" Grid.ColumnSpan="2" Height="30" Click="ExecuteButton_Click"/>
+        <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 5 0 0">
+            <Button Content="Test Connection" Margin="5" Width="120" Click="TestConnectionButton_Click"/>
+            <Button Content="View Command-Line" Margin="5" Width="120" Click="ViewCommandLineButton_Click"/>
+            <Button Content="Execute" Margin="5" Width="80" Click="ExecuteButton_Click"/>
+        </StackPanel>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- add Test Connection and View Command-Line buttons
- implement connection testing feature that just runs `sqlcmd` with `SELECT 1`
- show final command line in a new window

## Testing
- `dotnet build SqlcmdGuiApp/SqlcmdGuiApp.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a733f7bbc8332b22d5d6ce93cb4ca