### PR TITLE
Fix encrypt option

### DIFF
--- a/SqlcmdGuiApp/MainWindow.xaml
+++ b/SqlcmdGuiApp/MainWindow.xaml
@@ -44,14 +44,7 @@
                 <TextBlock Text="Password:" Margin="10 0"/>
                 <PasswordBox x:Name="PasswordBox" Width="100"/>
             </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0 2">
-                <TextBlock Text="Encrypt:" Width="80"/>
-                <ComboBox x:Name="EncryptComboBox" Width="200">
-                    <ComboBoxItem Content="true" IsSelected="True"/>
-                    <ComboBoxItem Content="false"/>
-                    <ComboBoxItem Content="disable"/>
-                </ComboBox>
-            </StackPanel>
+            <CheckBox x:Name="EncryptCheckBox" Content="Encrypt Connection" Margin="0 2"/>
             <CheckBox x:Name="TrustServerCertificateCheckBox" Content="Trust Server Certificate" Margin="0 2"/>
             <CheckBox x:Name="ReadOnlyIntentCheckBox" Content="ReadOnly Application Intent" Margin="0 2"/>
         </StackPanel>

--- a/SqlcmdGuiApp/MainWindow.xaml.cs
+++ b/SqlcmdGuiApp/MainWindow.xaml.cs
@@ -88,11 +88,9 @@ namespace SqlcmdGuiApp
                 args.Add("-E");
             }
 
-            var encrypt = (EncryptComboBox.SelectedItem as ComboBoxItem)?.Content?.ToString()?.ToLower();
-            if (!string.IsNullOrEmpty(encrypt))
+            if (EncryptCheckBox.IsChecked == true)
             {
                 args.Add("-N");
-                args.Add(encrypt);
             }
 
             if (TrustServerCertificateCheckBox.IsChecked == true)


### PR DESCRIPTION
## Summary
- replace encrypt dropdown with a single checkbox
- pass `-N` only when encryption is enabled

## Testing
- `dotnet build SqlcmdGuiApp/SqlcmdGuiApp.csproj -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a773a3a7c8332b64b50d3775dd0f4