### PR TITLE
Add config save/load support

### DIFF
--- a/SqlcmdGuiApp/Configuration.cs
+++ b/SqlcmdGuiApp/Configuration.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace SqlcmdGuiApp
+{
+    public class Configuration
+    {
+        public string FilePath { get; set; } = string.Empty;
+        public string Server { get; set; } = string.Empty;
+        public string Database { get; set; } = string.Empty;
+        public bool UseSqlAuth { get; set; }
+        public string User { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+        public bool Encrypt { get; set; }
+        public bool TrustServerCertificate { get; set; }
+        public bool ReadOnlyIntent { get; set; }
+        public List<SqlParameter> Parameters { get; set; } = new();
+    }
+}

--- a/SqlcmdGuiApp/MainWindow.xaml
+++ b/SqlcmdGuiApp/MainWindow.xaml
@@ -65,6 +65,8 @@
         </GroupBox>
 
         <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 5 0 0">
+            <Button Content="Load Config" Margin="5" Width="100" Click="LoadConfigButton_Click"/>
+            <Button Content="Save Config" Margin="5" Width="100" Click="SaveConfigButton_Click"/>
             <Button Content="Test Connection" Margin="5" Width="120" Click="TestConnectionButton_Click"/>
             <Button Content="View Command-Line" Margin="5" Width="120" Click="ViewCommandLineButton_Click"/>
             <Button Content="Execute" Margin="5" Width="80" Click="ExecuteButton_Click"/>


### PR DESCRIPTION
## Summary
- add buttons for loading and saving config to JSON
- implement Configuration class to hold settings
- implement SaveConfigButton_Click and LoadConfigButton_Click

## Testing
- `dotnet build SqlcmdGuiApp/SqlcmdGuiApp.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a7e5cb20483329d73f3c2b5bfb699