### PR TITLE
Add real-time status to output window

### DIFF
--- a/SqlcmdGuiApp/MainWindow.xaml.cs
+++ b/SqlcmdGuiApp/MainWindow.xaml.cs
@@ -246,6 +246,8 @@ namespace SqlcmdGuiApp
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
 
+                window.AttachProcess(process);
+
                 window.Show();
 
                 await process.WaitForExitAsync();

--- a/SqlcmdGuiApp/OutputWindow.xaml
+++ b/SqlcmdGuiApp/OutputWindow.xaml
@@ -2,7 +2,18 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="SQLCMD Output" Height="400" Width="600">
-    <Grid Margin="5">
+    <DockPanel Margin="5">
+        <StatusBar DockPanel.Dock="Bottom">
+            <StatusBarItem>
+                <TextBlock x:Name="StatusTextBlock" Text="Status: Running" />
+            </StatusBarItem>
+            <StatusBarItem>
+                <TextBlock x:Name="DurationTextBlock" Text="Duration: 00:00:00" />
+            </StatusBarItem>
+            <StatusBarItem HorizontalAlignment="Right">
+                <Button x:Name="StopButton" Content="Stop" Width="60" Click="StopButton_Click"/>
+            </StatusBarItem>
+        </StatusBar>
         <TextBox x:Name="OutputTextBox" IsReadOnly="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"/>
-    </Grid>
+    </DockPanel>
 </Window>

--- a/SqlcmdGuiApp/OutputWindow.xaml.cs
+++ b/SqlcmdGuiApp/OutputWindow.xaml.cs
@@ -1,9 +1,17 @@
+using System;
+using System.Diagnostics;
 using System.Windows;
+using System.Windows.Threading;
 
 namespace SqlcmdGuiApp
 {
     public partial class OutputWindow : Window
     {
+        private DispatcherTimer? _timer;
+        private readonly Stopwatch _stopwatch = new();
+        private Process? _process;
+        private bool _cancelled;
+
         public OutputWindow()
         {
             InitializeComponent();
@@ -14,6 +22,36 @@ namespace SqlcmdGuiApp
             OutputTextBox.Text = string.IsNullOrWhiteSpace(error) ? output : output + "\n" + error;
         }
 
+        public void AttachProcess(Process process)
+        {
+            _process = process;
+            _process.Exited += Process_Exited;
+
+            _stopwatch.Start();
+            _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+            _timer.Tick += (s, e) =>
+            {
+                DurationTextBlock.Text = $"Duration: {_stopwatch.Elapsed:hh\\:mm\\:ss}";
+            };
+            _timer.Start();
+
+            StatusTextBlock.Text = "Status: Running";
+            DurationTextBlock.Text = "Duration: 00:00:00";
+        }
+
+        private void Process_Exited(object? sender, EventArgs e)
+        {
+            _timer?.Stop();
+            _stopwatch.Stop();
+            Dispatcher.Invoke(() =>
+            {
+                string status = _cancelled ? "Cancelled" : (_process?.ExitCode == 0 ? "Completed" : "Failed");
+                StatusTextBlock.Text = $"Status: {status}";
+                DurationTextBlock.Text = $"Duration: {_stopwatch.Elapsed:hh\\:mm\\:ss}";
+                StopButton.IsEnabled = false;
+            });
+        }
+
         public void AppendOutput(string text)
         {
             Dispatcher.Invoke(() =>
@@ -21,6 +59,22 @@ namespace SqlcmdGuiApp
                 OutputTextBox.AppendText(text);
                 OutputTextBox.ScrollToEnd();
             });
+        }
+
+        private void StopButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_process != null && !_process.HasExited)
+            {
+                _cancelled = true;
+                try
+                {
+                    _process.Kill();
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- show command status in OutputWindow and allow manual cancellation
- update `MainWindow` to attach the process to OutputWindow

## Testing
- `dotnet build SqlcmdGuiApp/SqlcmdGuiApp.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a87d5e3f48332a61a6134e6961b77