### PR TITLE
Add sqlcmd -b flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,7 @@ dotnet run --project SqlcmdGuiApp/SqlcmdGuiApp.csproj
 ```
 
 You need the `sqlcmd` utility available in your PATH for the execution step to work.
+The application invokes `sqlcmd` with the `-b` option so that any errors result
+in a non-zero exit code.
 
 Any unhandled errors encountered by the application are written to `error.log` in the application directory.

--- a/SqlcmdGuiApp/MainWindow.xaml.cs
+++ b/SqlcmdGuiApp/MainWindow.xaml.cs
@@ -69,7 +69,8 @@ namespace SqlcmdGuiApp
 
         private List<string> BuildSqlcmdArguments(bool includeInputFile)
         {
-            var args = new List<string> { "-S", ServerTextBox.Text };
+            // Use -b so sqlcmd returns a non-zero exit code on errors
+            var args = new List<string> { "-b", "-S", ServerTextBox.Text };
 
             if (!string.IsNullOrEmpty(DatabaseTextBox.Text))
             {


### PR DESCRIPTION
## Summary
- ensure `sqlcmd` returns failure status with `-b`
- document that the application uses `-b`

## Testing
- `dotnet build SqlcmdGuiApp/SqlcmdGuiApp.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a8f305fc483329e15532d8b096d37