### PR TITLE
Fix auth panel initialization call

### DIFF
--- a/SqlcmdGuiApp/MainWindow.xaml.cs
+++ b/SqlcmdGuiApp/MainWindow.xaml.cs
@@ -26,10 +26,15 @@ namespace SqlcmdGuiApp
             ParametersPanel.ItemsSource = Parameters;
 
             // Set initial visibility and account information
-            AuthComboBox_SelectionChanged(null, null);
+            UpdateAuthPanels();
         }
 
         private void AuthComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            UpdateAuthPanels();
+        }
+
+        private void UpdateAuthPanels()
         {
             if (SqlAuthPanel == null || WindowsAuthPanel == null) return; // may be null during XAML load
             var useSqlAuth = AuthComboBox.SelectedIndex == 1;


### PR DESCRIPTION
## Summary
- avoid passing nulls when initializing auth panel
- create helper UpdateAuthPanels and reuse

## Testing
- `dotnet build SqlcmdGuiApp/SqlcmdGuiApp.csproj` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685ab6f3461083329bc4c538594bb92c